### PR TITLE
Fix urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
 <head> 
 <meta -equiv="content-type" content="text/html; charset=utf-8"/> 
 <title>Akihabara</title>
@@ -106,7 +106,7 @@ ul li a {
 </head> 
 <body onload="updatemap(35.698234,139.772412,11.25,12)">
 <div id="container">
-<div><a href="://www.tokyohackerspace.org/"><img src="ths_logo.png" width="260" height="103" border="0"></a></div>
+<div><a href="https://www.tokyohackerspace.org/"><img src="ths_logo.png" width="260" height="103" border="0"></a></div>
 <a id="anchor"></a>
 <div class="yt_holder">
     	<div id="ytvideo"></div>
@@ -146,7 +146,7 @@ ul li a {
 
 <div style="clear:both;"></div>
 <div class="yt_holder" style="width: 870px; text-align: center; font-family: georgia; font-size: 12px;">
-by Akiba from <a href="://freaklabs.org">Freaklabs</a> & psc from <a href="http://www.workinprogress.ca">workinprogress</a>
+by Akiba from <a href="http://freaklabs.org">Freaklabs</a> & psc from <a href="http://www.workinprogress.ca">workinprogress</a>
 </div>
 <div style="clear:both;"></div>
 


### PR DESCRIPTION
Many of the hrefs were set with URLs that didn't include the initial http[s] before ://. This prevented returning to the home page from /akihabara/ within the TokyoHackerspace website.